### PR TITLE
Remove white space in rendered content

### DIFF
--- a/layouts/shortcodes/rsvp.html
+++ b/layouts/shortcodes/rsvp.html
@@ -1,10 +1,10 @@
-{{ if .Get "href" }}
+{{ if .Get "href" -}}
 	{{ $href := .Get "href" }}
 
-	{{ if .Get "text" }}
+	{{- if .Get "text" -}}
 		<data class="p-rsvp" value="yes" /> <a href="{{ $href }}" class="u-in-reply-to">{{ .Get "text" }}</a>	
-	{{ else }}
+	{{- else -}}
 		<data class="p-rsvp" value="yes" /> <a href="{{ $href }}" class="u-in-reply-to">📅</a>	
-	{{ end }}
+	{{- end -}}
 
-{{ end }}
+{{- end }}


### PR DESCRIPTION
When cross posting to mastodon, the output would have a lot of white space.

Compare the post:
https://mandarismoore.com/2024/02/07/im-planning-on.html

To mastodon:
https://social.lol/@mandaris/111891340517133728